### PR TITLE
Fixed compatability requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PlasmoAlgorithms.jl
 
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://plasmo-dev.github.io/PlasmoAlgorithms.jl/dev/)
+
 This repository is designed to be a location for meta-algorithms for OptiGraphs with Plasmo.jl. The `\lib` directory contains the algorithms implemented in Plasmo.jl, and these algorithms can be added as packages in Julia.
 
 In the future, we hope to support several decomposition algorithms that exploit the graph structure of Plasmo.jl. Currently, only Benders decomposition is hosted in this directory (as PlasmoBenders.jl), but other algorithms are possible and will likely be added in the future. If you would like to develop a decomposition approach for Plasmo.jl OptiGraphs, we welcome any pull requests and contributions. 

--- a/lib/PlasmoBenders/Project.toml
+++ b/lib/PlasmoBenders/Project.toml
@@ -11,6 +11,8 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 julia = "1"
+JuMP = "1.2"
+MathOptInterface = "1.6"
 Plasmo = ">= 0.6.2"
 
 [extras]

--- a/lib/PlasmoBenders/Project.toml
+++ b/lib/PlasmoBenders/Project.toml
@@ -13,7 +13,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 julia = "1"
 JuMP = "1.2"
 MathOptInterface = "1.6"
-Plasmo = ">= 0.6.2"
+Plasmo = "^0.6.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
When trying to register the package, the merging was flagged [here](https://github.com/JuliaRegistries/General/pull/122114) because the compat section of PlasmoBenders was not set correctly. This PR resolves that. 

Also, a badge was added to the documentation on PlasmoAlgorithms.jl readme