### PR TITLE
Fixed bug in multicuts, added API functions, updated docs

### DIFF
--- a/docs/src/PlasmoBenders/sizing_tutorial.md
+++ b/docs/src/PlasmoBenders/sizing_tutorial.md
@@ -151,19 +151,19 @@ T = length(all_nodes(g1))
 
 ## Solving with PlasmoBenders
 
-The subgraphs of this problem form a tree structure (two subgraphs with edges connecting them), so we can now apply BD via PlasmoBenders. We will create the `BendersOptimizer` object by calling 
+The subgraphs of this problem form a tree structure (two subgraphs with edges connecting them), so we can now apply BD via PlasmoBenders. We will create the `BendersAlgorithm` object by calling 
 
 ```julia
 # Define a subproblem object to use for the subgraphs
 solver = optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false)
 
-# Define the BendersOptimizer object and set the subproblem solver
-benders_opt = BendersOptimizer(g, g_root, solver = solver)
+# Define the BendersAlgorithm object and set the subproblem solver
+benders_alg = BendersAlgorithm(g, g_root, solver = solver)
 ```
 
-The `BendersOptimizer` object can now be solved by calling 
+The `BendersAlgorithm` object can now be solved by calling 
 ```julia
-optimize!(benders_opt)
+run_algorithm!(benders_alg)
 ```
 
 The upper and lower bounds and the gap from the BD algorithm are shown below. 
@@ -211,7 +211,7 @@ With these new subgraphs defined, we need to link the variables to the root grap
 @linkconstraint(g, [t = 1:T], g3[:n][t][:x_buy] - g3[:n][t][:x_save] <= g_root[:n_root][:reactor_size])
 ```
 
-We can now call the `BendersOptimizer` function and solve this problem as before. In addition, if desired, we could set additional solver options, such as `multicut = false` (this uses one extra iteration) or `regularize = true` (which decreases the number of required iterations by 1). 
+We can now call the `BendersAlgorithm` function and solve this problem as before. In addition, if desired, we could set additional solver options, such as `multicut = false` (this uses one extra iteration) or `regularize = true` (which decreases the number of required iterations by 1). 
 
 !!! note
-    PlasmoBenders currently does not create a copy of the graph that is passed to the optimizer. This means that the graph `g` can't be altered with adding `g2` and `g3` after the original `BendersOptimizer` object is created. Instead, a new graph must be created and a new `BendersOptimizer` object must be formed for running the stochastic case above. 
+    PlasmoBenders currently does not create a copy of the graph that is passed to the optimizer. This means that the graph `g` can't be altered with adding `g2` and `g3` after the original `BendersAlgorithm` object is created. Instead, a new graph must be created and a new `BendersAlgorithm` object must be formed for running the stochastic case above. 

--- a/docs/src/PlasmoBenders/sizing_tutorial.md
+++ b/docs/src/PlasmoBenders/sizing_tutorial.md
@@ -17,7 +17,7 @@ The example below is a simplified problem where we need to choose the size of a 
     &\; r_{size} = \sum_{i \in N} z^r_i \lambda^{reactor}_i, \quad \sum_{i \in N} z^r_i = 1 \\ 
     &\; 0 \le x^{store}_t \le s_{size}, \quad t = 1, ..., T \\
     &\; 0 \le x^{buy}_t - x^{save}_t \le r_{size}, \quad t = 1, ..., T\\
-    &\; 0 \le x^{sell}_t \le \overline{d}^{sell}, \quad t = 1, ..., T \\
+    &\; 0 \le y^{product}_t \le \overline{d}^{sell}, \quad t = 1, ..., T \\
     &\; \underline{d}^{save} \le x^{save}_t \le \overline{d}^{save}, \quad t = 1, ..., T \\
     &\; x^{store}_1 = \bar{x}^{store}
 \end{align*}

--- a/docs/src/PlasmoBenders/storage_tutorial.md
+++ b/docs/src/PlasmoBenders/storage_tutorial.md
@@ -70,7 +70,7 @@ partition = Plasmo.Partition(graph, node_membership_vector)
 
 apply_partition!(graph, partition)
 
-for subgraph in getsubgraphs(graph)
+for subgraph in local_subgraphs(graph)
     set_to_node_objectives(subgraph)
 end
 ```
@@ -81,13 +81,13 @@ The resulting problem can be visualized as:
 
 ## Solving with PlasmoBenders
 
-The subgraphs have a (linear) tree structure, so we can pass this graph to PlasmoBenders' `BendersOptimizer` constructor and solve it with Nested Benders Decomposition. This also requires setting a "root subgraph." We will set the first subgraph as the root subgraph, but any of the subgraphs could be used. 
+The subgraphs have a (linear) tree structure, so we can pass this graph to PlasmoBenders' `BendersAlgorithm` constructor and solve it with Nested Benders Decomposition. This also requires setting a "root subgraph." We will set the first subgraph as the root subgraph, but any of the subgraphs could be used. 
 
 ```julia
 solver = optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false)
 
-root_graph = getsubgraphs(graph)[1]
-BendersOptimizer(graph, root_graph, solver = solver)
+root_graph = local_subgraphs(graph)[1]
+BendersAlgorithm(graph, root_graph, solver = solver)
 ```
 
 The Nested Benders scheme is able to reach the optimal solution after 5 iterations. The bounds and gap are shown below.
@@ -98,7 +98,7 @@ Note that the first iteration returns an upper bound that is well above the opti
 
 ## Querying Solutions
 
-PlasmoBenders provides access to API functions for querying the optimal solution from the BendersOptimizer object. We can query the solution by calling 
+PlasmoBenders provides access to API functions for querying the optimal solution from the BendersAlgorithm object. We can query the solution by calling 
 ```julia
 JuMP.objective_value(benders_opt)
 ```

--- a/lib/PlasmoBenders/src/PlasmoBenders.jl
+++ b/lib/PlasmoBenders/src/PlasmoBenders.jl
@@ -7,7 +7,7 @@ using Printf
 const PB = PlasmoBenders
 const MOI = MathOptInterface
 
-export BendersAlgorithm, relative_gap, run_algorithm!
+export BendersAlgorithm, relative_gap, run_algorithm!, get_upper_bounds
 
 include("Benders.jl")
 include("utils.jl")

--- a/lib/PlasmoBenders/src/solution.jl
+++ b/lib/PlasmoBenders/src/solution.jl
@@ -65,7 +65,7 @@ function _add_Benders_cuts!(optimizer::BendersAlgorithm)
             if !(get_multicut(optimizer))
                 theta_vars = _get_theta(optimizer, last_object)
                 theta_expr = sum(theta_vars[k] for k in 1:length(theta_vars))
-                _add_cut_constraint!(optimizer, last_object, theta_expr, rhs_expr)
+                _add_cut_constraint!(optimizer, last_object, theta_expr, agg_rhs_expr)
             end
         end
     end

--- a/lib/PlasmoBenders/test/DDP_LP_solve.jl
+++ b/lib/PlasmoBenders/test/DDP_LP_solve.jl
@@ -51,9 +51,14 @@ module TestDDP_LP_solves
     run_algorithm!(DDPOpt)
     @test isapprox(DDPOpt.best_upper_bound, 5.5, rtol = 1e-6)
 
-
     gtest = build_graph()
     DDPOpt = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20, multicut = true);
+    run_algorithm!(DDPOpt)
+    @test isapprox(DDPOpt.best_upper_bound, 5.5, rtol = 1e-6)
+    @test isapprox(get_gap(DDPOpt), 0, rtol = 1e-6)
+
+    gtest = build_graph()
+    DDPOpt = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20, multicut = false);
     run_algorithm!(DDPOpt)
     @test isapprox(DDPOpt.best_upper_bound, 5.5, rtol = 1e-6)
     @test isapprox(get_gap(DDPOpt), 0, rtol = 1e-6)

--- a/lib/PlasmoBenders/test/DDP_MIP.jl
+++ b/lib/PlasmoBenders/test/DDP_MIP.jl
@@ -77,7 +77,18 @@ function test_DDP_MIP_initialization()
         @test DDPOpt.binary_map[subgraphs[i]][node[:x]] == 0
     end
 
-    @test DDPOpt.time_init > 0
+    # Test API
+    @test get_graph(DDPOpt) == graph
+    @test get_root_object(DDPOpt) == subgraphs[1]
+    @test get_max_iters(DDPOpt) == max_iters
+    @test get_tol(DDPOpt) == tol
+    @test get_time_forward_pass(DDPOpt) == 0
+    @test get_time_backward_pass(DDPOpt) == 0
+    @test get_time_init(DDPOpt) > 0
+    @test typeof(get_time_iterations(DDPOpt)) <: Vector
+    @test typeof(get_lower_bounds(DDPOpt)) <: Vector
+    @test typeof(get_upper_bounds(DDPOpt, monotonic = true)) <: Vector
+    @test typeof(get_upper_bounds(DDPOpt, monotonic = false)) <: Vector
 
     # Test options
     set_strengthened!(DDPOpt, true)


### PR DESCRIPTION
There was an issue in the code for using aggregated cuts that referenced `rhs_expr` instead of `agg_rhs_expr`. This was updated. I also added API functions for querying data from the `BendersAlgorithm` object, and I updated the documentation that used an old `BendersOptimizer` reference in the examples. 