### PR TITLE
Fixed bug for objective functions with a single variable

### DIFF
--- a/lib/PlasmoBenders/src/utils.jl
+++ b/lib/PlasmoBenders/src/utils.jl
@@ -157,7 +157,7 @@ function _add_slack_to_node(optimizer::BendersAlgorithm, next_object, node::Plas
 
     # Ensure the objective is an Affine Expression
     if typeof(obj_func) == NodeVariableRef
-        obj_func = AffExpr(0, obj_func => 1)
+        obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}(0, obj_func => 1)
     end
 
     # Add the slacks to the objective function
@@ -194,7 +194,7 @@ function _add_slack_to_node_for_links(optimizer::BendersAlgorithm, next_object::
 
     # Ensure the objective is an Affine Expression
     if typeof(obj_func) == NodeVariableRef
-        obj_func = AffExpr(0, obj_func => 1)
+        obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}(0, obj_func => 1)
     end
 
     # Add the slacks to the objective function


### PR DESCRIPTION
Previously, the code handled the objective function differently if the objective function were an expression or a single variable reference (the latter occurs if the objective function is set to be a single variable with no multiplier). The `AffExpr` function is not compatible with `Plasmo.NodeVariableRef` types so we have to use `GenericAffExpr{Float64, NodeVariableRef}()` to create these expressions. The bug here comes from using `AffExpr` when I should have used `GenericAffExpr`. This PR fixes this bug and makes some small changes to test the new code in the unit tests. 