### PR TITLE
Fixed slow behavior of initialization

### DIFF
--- a/lib/PlasmoBenders/src/utils.jl
+++ b/lib/PlasmoBenders/src/utils.jl
@@ -158,6 +158,8 @@ function _add_slack_to_node(optimizer::BendersAlgorithm, next_object, node::Plas
     # Ensure the objective is an Affine Expression
     if typeof(obj_func) == NodeVariableRef
         obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}(0, obj_func => 1)
+    elseif typeof(obj_func) == nothing
+        obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}()
     end
 
     # Add the slacks to the objective function

--- a/lib/PlasmoBenders/src/utils.jl
+++ b/lib/PlasmoBenders/src/utils.jl
@@ -197,6 +197,8 @@ function _add_slack_to_node_for_links(optimizer::BendersAlgorithm, next_object::
     # Ensure the objective is an Affine Expression
     if typeof(obj_func) == NodeVariableRef
         obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}(0, obj_func => 1)
+    elseif typeof(obj_func) == nothing
+        obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}()
     end
 
     # Add the slacks to the objective function


### PR DESCRIPTION
The BendersAlgorithm initialization was very slow for problems with large numbers of variables in the linking constraints. This was mainly due to `intersect` and `union` calls that were often called several times for a single problem. These were used to get the set of variables on a linking constraint that belonged to a previous object (or the next object). I replaced these with vectors that just test the `source_graph` of the owning node for the variable. I was also able to remove the `union` call altogether because I realized I could compute the complicating variables more efficiently. The initialization time is much faster now for the problem I was testing on. 