### PR TITLE
Debugged feasible cuts, fixed slow initialization

### DIFF
--- a/lib/PlasmoBenders/src/solution.jl
+++ b/lib/PlasmoBenders/src/solution.jl
@@ -68,7 +68,7 @@ function _add_Benders_cuts!(optimizer::BendersAlgorithm)
 
                 if get_multicut(optimizer)
                     theta_var = _get_theta(optimizer, last_object, j)
-                    if optimizer.feasibility_list[i]
+                    if optimizer.feasibility_map[object]
                         _add_cut_constraint!(optimizer, last_object, theta_var, rhs_expr)
                     else
                         _add_feasibility_cut_constraint!(optimizer, last_object, rhs_expr)
@@ -158,13 +158,13 @@ function _optimize_in_forward_pass!(optimizer, i, ub)
 
     if object_termination_status
         _save_forward_pass_solutions(optimizer, next_object, ub)
-        optimizer.feasibility_list[i] = true
+        optimizer.feasibility_map[next_object] = true
     else
         # Need to do feasibility cuts; the check termination status function already tested
         # that feasibility_cuts was true
         println("Subgraph $i in forward pass was infeasible; using feasibility_cuts")
         _save_feasibility_cut_data(optimizer, next_object, ub)
-        optimizer.feasibility_list[i] = false
+        optimizer.feasibility_map[next_object] = false
     end
 
     _check_fixed_slacks!(optimizer, next_object)
@@ -286,11 +286,11 @@ function _optimize_in_backward_pass(optimizer, i)
 
         if object_termination_status
             next_phi = JuMP.value(object, JuMP.objective_function(object))
-            optimizer.feasibility_list[i] = true
+            optimizer.feasibility_map[object] = true
         else
             println("Subgraph $i in backwards pass was infeasible; using feasibility_cuts")
             next_phi = JuMP.dual_objective_value(object)
-            optimizer.feasibility_list[i] = false
+            optimizer.feasibility_map[object] = false
         end
 
         optimizer.dual_iters[object] = hcat(dual_iters, next_duals)

--- a/lib/PlasmoBenders/src/utils.jl
+++ b/lib/PlasmoBenders/src/utils.jl
@@ -1,6 +1,26 @@
-function Plasmo.incident_edges(graph::Plasmo.OptiGraph, subgraph::Plasmo.OptiGraph)
-    projection = hyper_projection(graph)
+function _get_hyper_projection(optimizer::BendersAlgorithm, graph::Plasmo.OptiGraph)
+    if haskey(optimizer.ext, "_projection")
+        return optimizer.ext["_projection"]
+    else
+        proj = Plasmo.hyper_projection(graph)
+        optimizer.ext["_projection"] = proj
+        return proj
+    end
+end
+
+function Plasmo.incident_edges(projection::T, subgraph::Plasmo.OptiGraph) where T <: Plasmo.GraphProjection
     return incident_edges(projection, all_nodes(subgraph))
+end
+
+function Plasmo.incident_edges(optimizer::BendersAlgorithm, graph::Plasmo.OptiGraph, subgraph::Plasmo.OptiGraph)
+    if haskey(optimizer.ext["incident_edges"], subgraph)
+        return optimizer.ext["incident_edges"][subgraph]
+    else
+        projection = _get_hyper_projection(optimizer, graph)
+        edges = Plasmo.incident_edges(projection, subgraph)
+        optimizer.ext["incident_edges"][subgraph] = edges
+        return edges
+    end
 end
 
 function _theta_value(optimizer::BendersAlgorithm, object::Plasmo.OptiGraph)


### PR DESCRIPTION
There was an error in how I implemented feasible cuts initially. I have been using the approach given [here](https://jump.dev/JuMP.jl/stable/tutorials/algorithms/benders_decomposition/#Feasibility-cuts) for the implementation, but I made the constraint at this link less than or equal to theta rather than less than or equal to zero. I fixed this by adding a `feasibility_map` attribute to the optimizer to keep track of whether each solve is feasible or not and added a new function that adds feasibility cuts. 

There was also an issue with the initialization, where, for a problem with multiple connections in the next stage, it computes the incident edges over and over as well as computing a new projection for the graph every time. This led to some very slow initialization of the `BendersAlgorithm` object. I added code to store this in the `ext` attribute of the algorithm so that it only has to compute these values once and then reuses them as needed.