### PR TITLE
Fixed Bug with Feasibility Cuts in MILP Subproblems

### DIFF
--- a/lib/PlasmoBenders/Project.toml
+++ b/lib/PlasmoBenders/Project.toml
@@ -1,7 +1,7 @@
 name = "PlasmoBenders"
 uuid = "491f1417-53b2-48aa-b9da-44cdd6c031b7"
 authors = ["David Cole"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Plasmo = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"

--- a/lib/PlasmoBenders/src/solution.jl
+++ b/lib/PlasmoBenders/src/solution.jl
@@ -219,6 +219,10 @@ end
 function _save_feasibility_cut_data(optimizer, next_object, ub)
     # See JuMP documentation for implementation of this method:
     # https://jump.dev/JuMP.jl/stable/tutorials/algorithms/benders_decomposition/#Feasibility-cuts
+
+    ub[1] = Inf
+
+    # Save primal information to upcoming objects
     if !optimizer.is_MIP
         obj_val = JuMP.dual_objective_value(next_object)
 
@@ -228,12 +232,7 @@ function _save_feasibility_cut_data(optimizer, next_object, ub)
         else
             theta_val = 0
         end
-    end
-
-    # Save primal information to upcoming objects
-    ub[1] = Inf
-
-    if !optimizer.is_MIP
+        
         next_duals = _get_next_duals(optimizer, next_object)
         dual_iters = optimizer.dual_iters[next_object]
         optimizer.dual_iters[next_object] = hcat(dual_iters, next_duals)

--- a/lib/PlasmoBenders/src/solution.jl
+++ b/lib/PlasmoBenders/src/solution.jl
@@ -219,13 +219,15 @@ end
 function _save_feasibility_cut_data(optimizer, next_object, ub)
     # See JuMP documentation for implementation of this method:
     # https://jump.dev/JuMP.jl/stable/tutorials/algorithms/benders_decomposition/#Feasibility-cuts
-    obj_val = JuMP.dual_objective_value(next_object)
+    if !optimizer.is_MIP
+        obj_val = JuMP.dual_objective_value(next_object)
 
-    next_objects = optimizer.solve_order_dict[next_object]
-    if length(next_objects) > 0
-        theta_val = _theta_value(optimizer, next_object)
-    else
-        theta_val = 0
+        next_objects = optimizer.solve_order_dict[next_object]
+        if length(next_objects) > 0
+            theta_val = _theta_value(optimizer, next_object)
+        else
+            theta_val = 0
+        end
     end
 
     # Save primal information to upcoming objects


### PR DESCRIPTION
There was an issue with the feasibility cuts when the problems beyond the first stage had mixed integer variables. It was caused by trying to query the dual objective value of the MILP problem in the forward pass without relaxing the integer values. The integer values are relaxed in the backwards pass, so I added a test to make sure is_MIP = false before querying this value in the forward pass. 