### PR TITLE
Fixed bug with strengthened cuts and feasibilty cuts

### DIFF
--- a/lib/PlasmoBenders/Project.toml
+++ b/lib/PlasmoBenders/Project.toml
@@ -1,7 +1,7 @@
 name = "PlasmoBenders"
 uuid = "491f1417-53b2-48aa-b9da-44cdd6c031b7"
 authors = ["David Cole"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Plasmo = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"


### PR DESCRIPTION
There was an error when strengthened cuts and feasibilty cuts are both set to be true. The lagrangian relaxation (LR) performed for the strengthened cuts is feasible even when the forward pass was infeasible, so the strengthened cuts would be added but with the dual value queried from the infeasible run. No clue if those will be remotely tight, so I think it is best that no LR is performed in the infeasible case and the cuts are added as feasibility cuts. This PR does that. 