### PR TITLE
Fixed typo with slack and empty objective

### DIFF
--- a/lib/PlasmoBenders/src/utils.jl
+++ b/lib/PlasmoBenders/src/utils.jl
@@ -178,7 +178,7 @@ function _add_slack_to_node(optimizer::BendersAlgorithm, next_object, node::Plas
     # Ensure the objective is an Affine Expression
     if typeof(obj_func) == NodeVariableRef
         obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}(0, obj_func => 1)
-    elseif typeof(obj_func) == nothing
+    elseif typeof(obj_func) == Nothing
         obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}()
     end
 
@@ -217,7 +217,7 @@ function _add_slack_to_node_for_links(optimizer::BendersAlgorithm, next_object::
     # Ensure the objective is an Affine Expression
     if typeof(obj_func) == NodeVariableRef
         obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}(0, obj_func => 1)
-    elseif typeof(obj_func) == nothing
+    elseif typeof(obj_func) == Nothing
         obj_func = GenericAffExpr{Float64, Plasmo.NodeVariableRef}()
     end
 


### PR DESCRIPTION
I tested the Benders algorithm with some models of my own and had to make a minor change to run it with slack to compensate for an empty objective. It should be `typeof(obj_func) == Nothing` rather than `typeof(obj_func) == nothing`, since `nothing` is not a type, e.g. `typeof(nothing) = Nothing`. Everything else worked amazingly smoothly though!