### PR TITLE
Fixed bug in remote optigraph multithreading

### DIFF
--- a/lib/PlasmoBenders/Project.toml
+++ b/lib/PlasmoBenders/Project.toml
@@ -1,7 +1,7 @@
 name = "PlasmoBenders"
 uuid = "491f1417-53b2-48aa-b9da-44cdd6c031b7"
 authors = ["David Cole"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Plasmo = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"

--- a/lib/PlasmoBenders/src/solution.jl
+++ b/lib/PlasmoBenders/src/solution.jl
@@ -107,7 +107,7 @@ function _optimize_in_forward_pass_multithread!(optimizer::BendersAlgorithm{Remo
         @async begin
             next_object = optimizer.solve_order[i]
 
-            is_feasible, obj_val, duals, t_solve = _optimize_remote_graph_forward(optimizer, next_object)
+            is_feasible, obj_val, duals, t_solve = _optimize_remote_graph_forward(optimizer, next_object, i)
             
             optimizer.time_subproblem_solves += t_solve
             if !is_feasible
@@ -131,10 +131,11 @@ function _optimize_in_forward_pass_multithread!(optimizer::BendersAlgorithm{Remo
     end
 end
 
-function _optimize_remote_graph_forward(optimizer::BendersAlgorithm, next_object::RemoteOptiGraph)
+function _optimize_remote_graph_forward(optimizer::BendersAlgorithm, next_object::RemoteOptiGraph, i::Int)
     feasibility_cuts = get_feasibility_cuts(optimizer)
     regularize = get_regularize(optimizer)
     add_slacks = get_add_slacks(optimizer)
+    is_MIP = get_is_MIP(optimizer)
 
     comp_vars = optimizer.comp_vars[next_object]
     var_copy_map = optimizer.var_copy_map[next_object]

--- a/lib/PlasmoBenders/test/LP_solve.jl
+++ b/lib/PlasmoBenders/test/LP_solve.jl
@@ -158,6 +158,18 @@ function test_graphs()
     @test isapprox(BendersAlg.best_upper_bound, 5.5, rtol = 1e-6)
     @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
 
+    gtest = build_graph()
+    BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20, multicut = true, regularize = false, parallelize_benders = false);
+    run_algorithm!(BendersAlg)
+    @test isapprox(BendersAlg.best_upper_bound, 5.5, rtol = 1e-6)
+    @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
+    gtest = build_graph()
+    BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[2], max_iters = 20, multicut = true, parallelize_benders = true);
+    run_algorithm!(BendersAlg)
+    @test isapprox(BendersAlg.best_upper_bound, 5.5, rtol = 1e-6)
+    @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
     # RemoteOptiGraphs
     gtest = build_remote_graph()
     BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20);
@@ -212,6 +224,18 @@ function test_graphs()
 
     gtest = build_remote_graph()
     BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20, multicut = true, regularize = false, parallelize_backward = true);
+    run_algorithm!(BendersAlg)
+    @test isapprox(BendersAlg.best_upper_bound, 5.5, rtol = 1e-6)
+    @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
+    gtest = build_remote_graph()
+    BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20, multicut = true, regularize = false, parallelize_benders = false);
+    run_algorithm!(BendersAlg)
+    @test isapprox(BendersAlg.best_upper_bound, 5.5, rtol = 1e-6)
+    @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
+    gtest = build_remote_graph()
+    BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[2], max_iters = 20, multicut = true, parallelize_benders = true);
     run_algorithm!(BendersAlg)
     @test isapprox(BendersAlg.best_upper_bound, 5.5, rtol = 1e-6)
     @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)

--- a/lib/PlasmoBenders/test/MIP_solve.jl
+++ b/lib/PlasmoBenders/test/MIP_solve.jl
@@ -130,6 +130,18 @@ module Test_MIP_solves
         run_algorithm!(BendersAlg)
         @test isapprox(BendersAlg.best_upper_bound, 5.8, rtol = 1e-6)
         @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+        
+        gtest = build_graph()
+        BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[2], max_iters = 20, multicut = true, regularize = false, parallelize_benders = false, strengthened = true);
+        run_algorithm!(BendersAlg)
+        @test isapprox(BendersAlg.best_upper_bound, 5.8, rtol = 1e-6)
+        @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
+        gtest = build_graph()
+        BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[2], max_iters = 20, multicut = true, parallelize_benders = true, strengthened = true);
+        run_algorithm!(BendersAlg)
+        @test isapprox(BendersAlg.best_upper_bound, 5.8, rtol = 1e-6)
+        @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
 
         # RemoteOptiGraph
         gtest = build_remote_graph()
@@ -163,6 +175,18 @@ module Test_MIP_solves
         gtest = build_remote_graph()
         BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[1], max_iters = 20, strengthened = true, multicut = true, regularize = false, parallelize_backward = true
         );
+        run_algorithm!(BendersAlg)
+        @test isapprox(BendersAlg.best_upper_bound, 5.8, rtol = 1e-6)
+        @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
+        gtest = build_remote_graph()
+        BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[2], max_iters = 20, multicut = true, regularize = false, parallelize_benders = false, strengthened = true);
+        run_algorithm!(BendersAlg)
+        @test isapprox(BendersAlg.best_upper_bound, 5.8, rtol = 1e-6)
+        @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)
+
+        gtest = build_remote_graph()
+        BendersAlg = BendersAlgorithm(gtest, local_subgraphs(gtest)[2], max_iters = 20, multicut = true, parallelize_benders = true, strengthened = true);
         run_algorithm!(BendersAlg)
         @test isapprox(BendersAlg.best_upper_bound, 5.8, rtol = 1e-6)
         @test isapprox(get_gap(BendersAlg), 0, rtol = 1e-6)


### PR DESCRIPTION
There was a bug in querying the termination status of the subproblems on remote optigraphs. There was also a missing call to the `is_MIP` field of the optimizer that was added. This PR fixes those bugs and also adds tests that would have caught this bug had they been there before. 