### PR TITLE
Updated tests to prevent hang on macos

### DIFF
--- a/.ci/ci.jl
+++ b/.ci/ci.jl
@@ -36,24 +36,26 @@ resolved by Julia's package manager according to the package's compat bounds.
 function test_package(pkg::AbstractString)
 	envdir = joinpath(@__DIR__, "env-" * pkg)
 	_clean_env!(envdir)
+	t0 = time()
 
 	# Activate isolated env for this package
+	@info "[$(pkg)] Activating isolated environment" envdir=envdir timestamp=Dates.now()
 	Pkg.activate(envdir)
 
 	# Bring the target package into this environment in development mode
+	@info "[$(pkg)] Developing package from local path" timestamp=Dates.now()
 	Pkg.develop(PackageSpec(path = joinpath(@__DIR__, "..", "lib", pkg)))
 
-	# Resolve, build, and precompile before testing
+	# Resolve dependencies for this package.
+	# Avoid explicit build/precompile here because these phases can hang on some CI
+	# runners; `Pkg.test` will perform required build/precompile work as needed.
+	@info "[$(pkg)] Instantiating dependencies" timestamp=Dates.now()
+	ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"
 	Pkg.instantiate()
-	Pkg.build()
-	try
-		Pkg.precompile()
-	catch err
-		@warn "Precompile failed; proceeding to tests" exception=(err, catch_backtrace())
-	end
 
-	@info "Running tests for $(pkg) (auto-resolved dependencies)" timestamp=Dates.now()
+	@info "[$(pkg)] Running tests" timestamp=Dates.now()
 	Pkg.test(pkg; coverage = true)
+	@info "[$(pkg)] Finished successfully" elapsed_seconds=round(time() - t0; digits=2) timestamp=Dates.now()
 end
 
 # Allow selection via environment variables for CI job splitting.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
   benders:
     name: PlasmoBenders
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +37,7 @@ jobs:
   schwarz:
     name: PlasmoSchwarz
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Under #40, the macos test sometimes would hang. I thought it was resolved because the PR passed the tests, but after it merged, the test would hang again. I think this PR should resolve the problem by updating how the environment is built in .ci/ci.jl